### PR TITLE
Fix links to #one-time-access

### DIFF
--- a/index.html
+++ b/index.html
@@ -408,7 +408,7 @@
       </section>
 
       <section class="large-9 columns">
-        <h2 id="once-time-access">
+        <h2 id="one-time-access">
           One-time code <a href="#one-time-access">¶</a>
         </h2>
         <figure>


### PR DESCRIPTION
Links to #one-time-access were broken due to a typo in the corresponding element's id attribute.
