### PR TITLE
Refactor pattern page

### DIFF
--- a/_layouts/pattern.html
+++ b/_layouts/pattern.html
@@ -15,7 +15,7 @@ layout: default
     {% case page.images.size %}
       {% when 1 %}
       <div class="one-image {% if page.illustration_version == 1%}large-12 medium-12{% else %}large-4 large-offset-4 medium-4 medium-offset-4{% endif %} small-12 cell">
-        <!-- Adding specific class for certain images that don't fit in Firefox/Edge mobile versions -->
+        <!-- Adding specific class for certain images that don't fit in mobile versions -->
         <img id="content" tabindex="0" class="{% if page.images[0].url == '/images/behavioural-patterns.svg'
                         or page.images[0].url == '/images/inactivity-checking.svg'
                         or page.images[0].url == '/images/marketplace.svg'

--- a/_layouts/pattern.html
+++ b/_layouts/pattern.html
@@ -26,18 +26,7 @@ layout: default
       </div>
 
       {% when 2 %}
-      {% when 3 %}
-      <!-- When no script, multiple images and mobile screen size, display only 1 image. -->
-      <noscript>
-        <div class="no-script-image-div grid-x">
-          <div class="three-image small-12 cell phone">
-            <img id="content" tabindex="0" src="{{ page.images[1].url }}" alt="{{ alt_text }}"/>
-          </div>
         {% for image in page.images %}
-          <div class="three-image desktop large-4 medium-4 small-4 cell">
-            <!-- Hard-coded alt text as there is currently only one pattern with three images. Change this when new patterns added. -->
-            <img id="content" tabindex="0" src="{{ image.url }}" alt="A person generates a code on their device for another person to scan."/>
-          </div>
           {% if forloop.first == true %}
             <div class="two-image large-4 large-offset-2 medium-4 medium-offset-2 small-12 cell">
           {% else %}
@@ -46,22 +35,22 @@ layout: default
               <img id="content" tabindex="0" src="{{ image.url }}" alt="{{ alt_text }}" />
             </div>
         {% endfor %}
-        </div>
-      </noscript>
+
+      {% when 3 %}
       {% for image in page.images %}
         {% if forloop.index == 2 %}
-        <!-- Set second image as skip-to-content anchor -->
-        <!-- Hide this when script is turned off -->
-        <div class="large-4 medium-4 small-12 cell three-image when-no-script">
-          <img id="content" tabindex="0" src="{{ image.url }}" alt="{{ alt_text }}" />
-        </div>
+          <!-- Set second image as skip-to-content anchor -->
+          <div class="large-4 medium-4 small-12 cell three-image">
+            <img id="content" tabindex="0" src="{{ image.url }}" alt="{{ alt_text }}" />
+          </div>
         {% else %}
-          <!-- Hide this when script is turned off -->
-          <div class="large-4 medium-4 small-12 cell three-image when-no-script">
+          <!-- When no script and on mobile, hide these images. -->
+          <div class="large-4 medium-4 small-12 cell three-image desktop">
             <img src="{{ image.url }}" alt="{{ alt_text }}" />
           </div>
         {% endif %}
       {% endfor %}
+
     {% endcase %}
     <div class="carousel-indicator"><div class="wrapper"></div></div>
   {% endif %}

--- a/_layouts/pattern.html
+++ b/_layouts/pattern.html
@@ -56,7 +56,7 @@ layout: default
   {% endif %}
 </div>
 
-<div class="ie-content grid-x grid-padding-x">
+<div class="page-title {% if page.illustration_version == 1%} illustration_version_1 {% endif %} ie-content grid-x grid-padding-x">
   <div class="large-8 large-offset-2 small-12 cell">
     <h2 class="ie-title no-margin">{{ page.title }}</h2>
     <a aria-describedby="category-link-tip" href="/category/{{ page.category | slugify }}" class="pattern-page-category-link border-{{ page.category | slugify }}">{{ page.category }}</a>

--- a/_layouts/pattern.html
+++ b/_layouts/pattern.html
@@ -4,6 +4,8 @@ layout: default
 
 {% assign other_patterns = site.patterns | where: "category": page.category %}
 
+{% assign alt_text = page.alt %}
+
 <div class="full-width-banner pattern color-{{ page.category | slugify }}"></div>
 
 <div class="grid-x grid-padding-x pattern-image {% if page.illustration_version == 1 %} illustration_version_1{% endif %}">
@@ -11,7 +13,7 @@ layout: default
   <a href="#" class="carousel-control next">Next</a>
   {% if page.images %}
     {% case page.images.size %}
-      {% when 2 %}
+      {% when 1 %}
       <div class="one-image {% if page.illustration_version == 1%}large-12 medium-12{% else %}large-4 large-offset-4 medium-4 medium-offset-4{% endif %} small-12 cell">
         <!-- Adding specific class for certain images that don't fit in Firefox/Edge mobile versions -->
         <img id="content" tabindex="0" class="{% if page.images[0].url == '/images/behavioural-patterns.svg'
@@ -19,9 +21,9 @@ layout: default
                         or page.images[0].url == '/images/marketplace.svg'
                         or page.images[0].url == '/images/word-matching.svg' %}
                           shrink-height
-                        {% endif %}" src="{{ page.images[0].url }}" alt="{{ page.images[1].alt }}" />
+                        {% endif %}" src="{{ page.images[0].url }}" alt="{{ alt_text }}" />
       </div>
-      {% when 3 %}
+      {% when 2 %}
       {% assign count = 0 %}
       {% for image in page.images %}
         {% if count == 0 %}
@@ -29,16 +31,16 @@ layout: default
         {% else %}
           <div class="two-image large-4 medium-4 small-12 cell">
         {% endif %}
-            <img id="content" tabindex="0" src="{{ image.url }}" alt="{{ image.alt }}" />
+            <img id="content" tabindex="0" src="{{ image.url }}" alt="{{ alt_text }}" />
           </div>
         {% assign count = count | plus: 1 %}
       {% endfor %}
-      {% when 4 %}
+      {% when 3 %}
       <!-- When no script, multiple images and mobile screen size, display only 1 image. -->
       <noscript>
         <div class="no-script-image-div grid-x">
           <div class="three-image small-12 cell phone">
-            <img id="content" tabindex="0" src="{{ page.images[1].url }}" alt="{{ page.images[3].alt }}"/>
+            <img id="content" tabindex="0" src="{{ page.images[1].url }}" alt="{{ alt_text }}"/>
           </div>
         {% for image in page.images %}
           <div class="three-image desktop large-4 medium-4 small-4 cell">
@@ -49,18 +51,16 @@ layout: default
         </div>
       </noscript>
       {% for image in page.images %}
-        {% if forloop.last == true %}
-        <!-- Do not print altText as separate image. -->
-        {% elsif forloop.index == 2 %}
+        {% if forloop.index == 2 %}
         <!-- Set second image as skip-to-content anchor -->
         <!-- Hide this when script is turned off -->
         <div class="large-4 medium-4 small-12 cell three-image when-no-script">
-          <img id="content" tabindex="0" src="{{ image.url }}" alt="A person generates a code on their device for another person to scan." />
+          <img id="content" tabindex="0" src="{{ image.url }}" alt="{{ alt_text }}" />
         </div>
         {% else %}
           <!-- Hide this when script is turned off -->
           <div class="large-4 medium-4 small-12 cell three-image when-no-script">
-            <img src="{{ image.url }}" alt="A person generates a code on their device for another person to scan." />
+            <img src="{{ image.url }}" alt="{{ alt_text }}" />
           </div>
         {% endif %}
       {% endfor %}

--- a/_layouts/pattern.html
+++ b/_layouts/pattern.html
@@ -13,6 +13,7 @@ layout: default
   <a href="#" class="carousel-control next">Next</a>
   {% if page.images %}
     {% case page.images.size %}
+
       {% when 1 %}
       <div class="one-image {% if page.illustration_version == 1%}large-12 medium-12{% else %}large-4 large-offset-4 medium-4 medium-offset-4{% endif %} small-12 cell">
         <!-- Adding specific class for certain images that don't fit in mobile versions -->
@@ -23,18 +24,8 @@ layout: default
                           shrink-height
                         {% endif %}" src="{{ page.images[0].url }}" alt="{{ alt_text }}" />
       </div>
+
       {% when 2 %}
-      {% assign count = 0 %}
-      {% for image in page.images %}
-        {% if count == 0 %}
-          <div class="two-image large-4 large-offset-2 medium-4 medium-offset-2 small-12 cell">
-        {% else %}
-          <div class="two-image large-4 medium-4 small-12 cell">
-        {% endif %}
-            <img id="content" tabindex="0" src="{{ image.url }}" alt="{{ alt_text }}" />
-          </div>
-        {% assign count = count | plus: 1 %}
-      {% endfor %}
       {% when 3 %}
       <!-- When no script, multiple images and mobile screen size, display only 1 image. -->
       <noscript>
@@ -47,6 +38,13 @@ layout: default
             <!-- Hard-coded alt text as there is currently only one pattern with three images. Change this when new patterns added. -->
             <img id="content" tabindex="0" src="{{ image.url }}" alt="A person generates a code on their device for another person to scan."/>
           </div>
+          {% if forloop.first == true %}
+            <div class="two-image large-4 large-offset-2 medium-4 medium-offset-2 small-12 cell">
+          {% else %}
+            <div class="two-image large-4 medium-4 small-12 cell">
+          {% endif %}
+              <img id="content" tabindex="0" src="{{ image.url }}" alt="{{ alt_text }}" />
+            </div>
         {% endfor %}
         </div>
       </noscript>

--- a/_patterns/access-through-a-letter.md
+++ b/_patterns/access-through-a-letter.md
@@ -7,7 +7,8 @@ category: Control access
 
 images:
 - url: /images/access-through-letter.svg
-- alt: A person's hand hovers their mobile phone over a bar code in an energy bill.
+
+alt: A person's hand hovers their mobile phone over a bar code in an energy bill.
 
 advantages:
  - Relies on some having access to a specific address

--- a/_patterns/access-through-secondary-means.md
+++ b/_patterns/access-through-secondary-means.md
@@ -9,7 +9,8 @@ category: Control access
 
 images:
   - url: /images/access-through-secondary-means.svg
-  - alt: An email has a link which logs you in to another service.
+
+alt: An email has a link which logs you in to another service.
 
 
 examples:

--- a/_patterns/active-request.md
+++ b/_patterns/active-request.md
@@ -9,7 +9,8 @@ category: Give consent
 
 images:
   - url: /images/active-request.svg
-  - alt: A dialog box asks users to share location data.
+
+alt: A dialog box asks users to share location data.
 
 examples:
   - title: Prolific Academic

--- a/_patterns/activity-based-permission.md
+++ b/_patterns/activity-based-permission.md
@@ -7,7 +7,8 @@ category: Control access
 
 images:
 - url: /images/activity-based-permission.svg
-- alt: A mobile phone is tilted, putting it in to sleep mode.
+
+alt: A mobile phone is tilted, putting it in to sleep mode.
 
 advantages:
  - Remains convenient while offering some form of security

--- a/_patterns/activity-log.md
+++ b/_patterns/activity-log.md
@@ -9,7 +9,8 @@ category: See access
 
 images:
   - url: /images/activity-log.svg
-  - alt: A list of when data has been accessed and an option to revoke access.
+
+alt: A list of when data has been accessed and an option to revoke access.
 
 examples:
   - title: Frequent locations in iOS

--- a/_patterns/automation-detection.md
+++ b/_patterns/automation-detection.md
@@ -7,7 +7,8 @@ category: Control access
 
 images:
 - url: /images/automation-detection.svg
-- alt: The words not a robot is written in wavy text, the word not is written underneath in regular text.
+
+alt: The words not a robot is written in wavy text, the word not is written underneath in regular text.
 
 advantages:
  - Reduces impact of automated access to systems, such as denial of service or spam

--- a/_patterns/behavioural-biometrics.md
+++ b/_patterns/behavioural-biometrics.md
@@ -7,7 +7,8 @@ category: Authentication
 
 images:
   - url: /images/behavioural-biometrics.svg
-  - alt: A computer monitor with the path of the cursor outlined on screen.
+
+alt: A computer monitor with the path of the cursor outlined on screen.
 
 further_reading:
   - title: An Efficient User Verification System via Mouse Movements (PDF)

--- a/_patterns/behavioural-patterns.md
+++ b/_patterns/behavioural-patterns.md
@@ -9,7 +9,8 @@ category: Authentication
 
 images:
   - url: /images/behavioural-patterns.svg
-  - alt: A message on a phone asking to confirm your password because it is a new or unfamiliar device.
+
+alt: A message on a phone asking to confirm your password because it is a new or unfamiliar device.
 
 examples:
   - description: Google and Facebook require people to sign in again if they're accessing services from a new location

--- a/_patterns/data-licences.md
+++ b/_patterns/data-licences.md
@@ -7,7 +7,8 @@ category: Manage consent
 
 images:
   - url: /images/data-licences.svg
-  - alt: Four icons representing different types of data sharing.
+
+alt: Four icons representing different types of data sharing.
 
 examples:
   - title: Data licences by IF

--- a/_patterns/decision-testing.md
+++ b/_patterns/decision-testing.md
@@ -7,7 +7,8 @@ category: Automation
 
 images:
 - url: /images/decision-testing.svg
-- alt: Two mobile phones side by side showing different outcomes of an automated decision.
+
+alt: Two mobile phones side by side showing different outcomes of an automated decision.
 
 advantages:
  - Learning by doing how an automated decision gets made

--- a/_patterns/delegate-permissions.md
+++ b/_patterns/delegate-permissions.md
@@ -9,7 +9,8 @@ category: Social consent
 
 images:
   - url: /images/delegate-permissions.svg
-  - alt: A message reading Facebook does not have access to your car. To enable access, tap settings and turn on Car.
+
+alt: A message reading Facebook does not have access to your car. To enable access, tap settings and turn on Car.
 
 examples:
   - title: OAuth

--- a/_patterns/emergency-contacts.md
+++ b/_patterns/emergency-contacts.md
@@ -9,7 +9,8 @@ category: Backup data
 
 images:
   - url: /images/emergency-contacts.svg
-  - alt: A dialog box asking if you if you want to give someone access to your account in an emergency.
+
+alt: A dialog box asking if you if you want to give someone access to your account in an emergency.
 
 examples:
   - title: LastPass

--- a/_patterns/end-to-end-encryption.md
+++ b/_patterns/end-to-end-encryption.md
@@ -9,7 +9,8 @@ category: Control access
 
 images:
   - url: /images/end-to-end-encryption.svg
-  - alt: An email where encryption is indicated by a lock icon and a checkmark.
+
+alt: An email where encryption is indicated by a lock icon and a checkmark.
 
 examples:
   - title: PGP

--- a/_patterns/future-decision-notice.md
+++ b/_patterns/future-decision-notice.md
@@ -7,7 +7,8 @@ category: Automation
 
 images:
 - url: /images/future-decision-notice.svg
-- alt: A prompt on a mobile device reading Pending - You're about save £7.23 and underneath a button reading Stop.
+
+alt: A prompt on a mobile device reading Pending - You're about save £7.23 and underneath a button reading Stop.
 
 advantages:
  - More control of a  automated decision

--- a/_patterns/geofencing.md
+++ b/_patterns/geofencing.md
@@ -9,7 +9,8 @@ category: Control access
 
 images:
   - url: /images/geofencing.svg
-  - alt: A mobile phone detects that the user is in Manchester and offers more information about the city.
+
+alt: A mobile phone detects that the user is in Manchester and offers more information about the city.
 
 examples:
   - title: iOS reminder app

--- a/_patterns/gesture-matching.md
+++ b/_patterns/gesture-matching.md
@@ -7,7 +7,8 @@ category: Authentication
 
 images:
   - url: /images/gesture-matching.svg
-  - alt: A hand tracing an unlock pattern on the lockscreen of a mobile device.
+
+alt: A hand tracing an unlock pattern on the lockscreen of a mobile device.
 
 examples:
   - title: Unlock pattern on Android

--- a/_patterns/implied-consent.md
+++ b/_patterns/implied-consent.md
@@ -9,7 +9,8 @@ category: Give consent
 
 images:
   - url: /images/implied-consent.svg
-  - alt: A website on a laptop screen with a banner which reads Welcome. This site uses cookies, read our policy here.
+
+alt: A website on a laptop screen with a banner which reads Welcome. This site uses cookies, read our policy here.
 
 examples:
   - title: EU 'Cookie Law'

--- a/_patterns/inactivity-checking.md
+++ b/_patterns/inactivity-checking.md
@@ -9,7 +9,8 @@ category: Control access
 
 images:
   - url: /images/inactivity-checking.svg
-  - alt: A message on a mobile phone which reads Are you still there? Data published in 29 seconds.
+
+alt: A message on a mobile phone which reads Are you still there? Data published in 29 seconds.
 
 examples:
   - title: Google Inactive Account Manager

--- a/_patterns/just-in-time-consent.md
+++ b/_patterns/just-in-time-consent.md
@@ -7,7 +7,8 @@ category: Give consent
 
 images:
   - url: /images/just-in-time-consent.svg
-  - alt: A prompt asking to access the location of a device to tag a photograph.
+
+alt: A prompt asking to access the location of a device to tag a photograph.
 
 examples:
   - title: iOS permissions

--- a/_patterns/key-ceremony.md
+++ b/_patterns/key-ceremony.md
@@ -7,7 +7,8 @@ category: Social consent
 
 images:
   - url: /images/key-ceremony.svg
-  - alt: Two keys inserted into locks at the same time.
+
+alt: Two keys inserted into locks at the same time.
 
 further_reading:
   - title: Meet the seven people who hold the keys to worldwide internet security

--- a/_patterns/marketplace.md
+++ b/_patterns/marketplace.md
@@ -9,7 +9,8 @@ category: Other
 
 images:
   - url: /images/marketplace.svg
-  - alt: A receipt showing sale of personal data.
+
+alt: A receipt showing sale of personal data.
 
 examples:
   - title: Datacoup

--- a/_patterns/multi-factor-using-a-generator.md
+++ b/_patterns/multi-factor-using-a-generator.md
@@ -5,7 +5,8 @@ title: Multi-factor using a generator
 
 images:
   - url: /images/multi-factor-with-generator.svg
-  - alt: A code is generated on a device and entered into a computer.
+
+alt: A code is generated on a device and entered into a computer.
 
 category: Authentication
 

--- a/_patterns/multi-factor-using-an-object.md
+++ b/_patterns/multi-factor-using-an-object.md
@@ -5,7 +5,8 @@ title: Multi-factor using an object
 
 images:
   - url: /images/multi-factor-with-object.svg
-  - alt: A memory card is inserted into a computer and a checkmark is displayed on screen.
+
+alt: A memory card is inserted into a computer and a checkmark is displayed on screen.
 
 category: Authentication
 

--- a/_patterns/multi-factor-using-text-message.md
+++ b/_patterns/multi-factor-using-text-message.md
@@ -7,7 +7,8 @@ category: Authentication
 
 images:
   - url: /images/multi-factor-with-text-message.svg
-  - alt: A code is shown in a text message on a mobile device and entered into a computer at the same time.
+
+alt: A code is shown in a text message on a mobile device and entered into a computer at the same time.
 
 examples:
 - title: Two Factor Auth List

--- a/_patterns/one-time-access.md
+++ b/_patterns/one-time-access.md
@@ -9,7 +9,8 @@ category: Share data
 
 images:
   - url: /images/one-time-access.svg
-  - alt: A dialog box shows a single-use code and a button which reads Use now.
+
+alt: A dialog box shows a single-use code and a button which reads Use now.
 
 examples:
   - title: UK Share Driving Licence service

--- a/_patterns/opt-in-to-give-consent.md
+++ b/_patterns/opt-in-to-give-consent.md
@@ -9,7 +9,8 @@ category: Give consent
 
 images:
   - url: /images/opt-in-to-give-consent.svg
-  - alt: An organ donor card in front a form for joining the Organ Donor's Register.
+
+alt: An organ donor card in front a form for joining the Organ Donor's Register.
 
 examples:
   - title: UK organ donations register

--- a/_patterns/opt-out-to-remove-consent.md
+++ b/_patterns/opt-out-to-remove-consent.md
@@ -9,7 +9,8 @@ category: Give consent
 
 images:
   - url: /images/opt-out-to-remove-consent.svg
-  - alt: Two devices display options to opt-out of location sharing and web browser tracking.
+
+alt: Two devices display options to opt-out of location sharing and web browser tracking.
 
 examples:
   - title: Do Not Track

--- a/_patterns/physical-biometrics.md
+++ b/_patterns/physical-biometrics.md
@@ -7,7 +7,8 @@ category: Authentication
 
 images:
   - url: /images/physical-biometrics.svg
-  - alt: A finger on a fingerprint scanner.
+
+alt: A finger on a fingerprint scanner.
 
 examples:
   - title: Touch ID

--- a/_patterns/physical-security.md
+++ b/_patterns/physical-security.md
@@ -7,7 +7,8 @@ category: Control access
 
 images:
   - url: /images/physical-security.svg
-  - alt: A graphic of a safe door hidden in a framed picture.
+
+alt: A graphic of a safe door hidden in a framed picture.
 
 examples:
   - title: Coinbase

--- a/_patterns/post-access-notification.md
+++ b/_patterns/post-access-notification.md
@@ -7,7 +7,8 @@ category: See access
 
 images:
   - url: /images/post-access-notification.svg
-  - alt: A letter reading 3 points added to your license after your recent road traffic offence.
+
+alt: A letter reading 3 points added to your license after your recent road traffic offence.
 
 examples:
   - description: Driving licence points

--- a/_patterns/private-link.md
+++ b/_patterns/private-link.md
@@ -9,7 +9,8 @@ category: Share data
 
 images:
   - url: /images/private-link.svg
-  - alt: A private link that enables people to share and view a document.
+
+alt: A private link that enables people to share and view a document.
 
 examples:
   - description: Services like Google Docs, Etherpad, Keybase file system and Dropbox have link sharing options

--- a/_patterns/proximity-sharing.md
+++ b/_patterns/proximity-sharing.md
@@ -7,7 +7,8 @@ category: Share data
 
 images:
  - url: /images/proximity-sharing.svg
- - alt: Two devices being held closer together, enabling them to share data over WiFi. 
+
+alt: Two devices being held closer together, enabling them to share data over WiFi. 
 
 advantages:
  - Data is shared directly between devices

--- a/_patterns/pseudo-anonymous-data.md
+++ b/_patterns/pseudo-anonymous-data.md
@@ -7,7 +7,8 @@ category: Share data
 
 images:
   - url: /images/pseudo-anonymous-data.svg
-  - alt: A test tube labelled with a bar code.
+
+alt: A test tube labelled with a bar code.
 
 advantages:
  - Data can be processed without revealing who it relates to

--- a/_patterns/recovery-codes.md
+++ b/_patterns/recovery-codes.md
@@ -7,7 +7,8 @@ category: Backup data
 
 images:
   - url: /images/recovery-codes.svg
-  - alt: A list of randomly generated alpha-numeric codes.
+
+alt: A list of randomly generated alpha-numeric codes.
 
 advantages:
   - Allows access to data when other factors are lost or unavailable

--- a/_patterns/secret-answer.md
+++ b/_patterns/secret-answer.md
@@ -9,7 +9,8 @@ category: Authentication
 
 images:
   - url: /images/secret-answer.svg
-  - alt: A form on a website asking for a password and answer to a secret question.
+
+alt: A form on a website asking for a password and answer to a secret question.
 
 examples:
   - description: Most authentication uses a form of secret answer

--- a/_patterns/smart-contract-access.md
+++ b/_patterns/smart-contract-access.md
@@ -9,7 +9,8 @@ category: Control access
 
 images:
   - url: /images/smart-contract-access.svg
-  - alt: An envelope with the words Open on your birthday written across it.
+
+alt: An envelope with the words Open on your birthday written across it.
 
 examples:
   - title: Ethereum

--- a/_patterns/terms-and-conditions.md
+++ b/_patterns/terms-and-conditions.md
@@ -9,7 +9,8 @@ category: Other
 
 images:
   - url: /images/terms-and-conditions.svg
-  - alt: A dialog box showing a terms and conditions agreement above Agree and Disagree buttons.
+
+alt: A dialog box showing a terms and conditions agreement above Agree and Disagree buttons.
 
 examples:
   - description: Most software during installation and digital services during registration

--- a/_patterns/time-limiting.md
+++ b/_patterns/time-limiting.md
@@ -9,7 +9,8 @@ category: Control access
 
 images:
   - url: /images/time-limiting.svg
-  - alt: A web window showing customizable sharing settings for accessing a service.
+
+alt: A web window showing customizable sharing settings for accessing a service.
 
 examples:
   - title: Google Docs

--- a/_patterns/up-front-consent.md
+++ b/_patterns/up-front-consent.md
@@ -7,7 +7,8 @@ category: Give consent
 
 images:
   - url: /images/up-front-consent.svg
-  - alt: A list of data a service has permission to access. 
+
+alt: A list of data a service has permission to access. 
 
 examples:
   - title: Google Play Store

--- a/_patterns/verifiable-proof.md
+++ b/_patterns/verifiable-proof.md
@@ -9,7 +9,8 @@ images:
   - url: /images/verifiable-proof-1.svg
   - url: /images/verifiable-proof-2.svg
   - url: /images/verifiable-proof-3.svg
-  - alt: A person generates a code on their device for another person to scan. 
+
+alt: A person generates a code on their device for another person to scan. 
 
 cover_image:
   - url: /images/verifiable-proof-2.svg

--- a/_patterns/word-matching.md
+++ b/_patterns/word-matching.md
@@ -9,7 +9,8 @@ category: Authentication
 
 images:
   - url: /images/word-matching.svg
-  - alt: The same security words are displayed on two different mobile phones.
+
+alt: The same security words are displayed on two different mobile phones.
 
 examples:
   - title: Signal

--- a/_patterns/zero-knowledge-sharing.md
+++ b/_patterns/zero-knowledge-sharing.md
@@ -7,7 +7,8 @@ category: Share data
 
 images:
   - url: /images/zero-knowledge-sharing.svg
-  - alt: A service confirms a person's age without revealing their date of birth to a second device.
+
+alt: A service confirms a person's age without revealing their date of birth to a second device.
 
 advantages:
  - Quicker to reach outcomes without having to process data

--- a/_sass/app.scss
+++ b/_sass/app.scss
@@ -1150,7 +1150,7 @@ a:focus{
 // Content can be presented without loss of information or functionality,
 // and without requiring scrolling in two dimensions for:
 //  - Vertical scrolling content at a width equivalent to 320 CSS pixels
-@media screen and (max-width: 320px) {
+@media screen and (max-width: 319px) {
   header {
     &.grid-container {
       padding-left: 10px;

--- a/_sass/app.scss
+++ b/_sass/app.scss
@@ -1150,106 +1150,25 @@ a:focus{
 // Content can be presented without loss of information or functionality,
 // and without requiring scrolling in two dimensions for:
 //  - Vertical scrolling content at a width equivalent to 320 CSS pixels
-@media screen and (max-width: 319px) {
+@media screen and (max-width: 320px) {
   header {
-    &.grid-container {
-      padding-left: 10px;
-      padding-right: 10px;
-    }
-
     h1 {
-      font-size: 18px;
-      left: 7px;
-    }
-
-    a {
-      display: inline-block;
-      margin: 0 auto;
+      font-size: 1.05rem;
     }
   }
-
-  main {
-    .homepage-intro {
-      padding-left: 10px;
-      padding-right: 10px;
-      padding-top: 60px;
-      margin-bottom: 0;
-
-      h2 {
-        font-size: 1.1em;
-        margin-bottom: 20px;
-      }
-    }
-
-    .cta {
-      padding: 13px 10px 10px;
-    }
-  }
-
-  .menu.fixed {
-    top: -10px;
-  }
-
-  .pattern-category-title {
-    padding-bottom: 0;
-    padding-top: 29px;
-    height: 59px;
-
-    &.fixed {
-      padding-top: 5px;
-      height: 32px;
-      justify-content: center;
-    }
-
-    img {
-      margin-top: 5px;
-    }
-
-    h2 {
-      font-size: 1rem;
-    }
-  }
-
-  .category-nav {
-    height: 158px;
-
-    ul {
-      margin-top: 2px;
-
-      li {
-        padding-bottom: 6px;
-        font-size: 11px;
-      }
-    }
-  }
-
-  .page-menu {
-    height: 100vh;
-  }
-
-  .full-width-banner {
-    &.pattern {
-      height: 100vh;
-    }
-  }
-
   .pattern-image {
-    height: 150px;
-
-    &.illustration_version_1 {
-      height: 155px;
-    }
+    margin-bottom: 0;
+    top: 1.5rem;
   }
 
-  .pattern-block {
-    .title {
-      font-size: 0.8em;
-    }
-
-    .image {
-      height: 200px;
-    }
+  .page-title {
+    margin-top: 6.5rem;
   }
+
+  .page-title.illustration_version_1 {
+    margin-top: 3.5rem;
+  }
+
 }
 
 @media screen and (max-width: 638px) and (-ms-high-contrast: none), (-ms-high-contrast: active) {

--- a/_sass/app.scss
+++ b/_sass/app.scss
@@ -733,7 +733,6 @@ h2#content {
   font-weight: bold;
   padding: 5px 10px;
 }
-// Not sure how to get around specificity issue with links? Have to use !important, it seems...
 
 .iframe-container:focus,
 a:focus{
@@ -769,6 +768,7 @@ a:focus{
 }
 
 /* MEDIA QUERIES */
+// 'Burger breakpoint' - 639px is breakpoint at which top menu turns back into list of links.
 @media screen and (min-width: 639px) {
   body {
     font-size: 22px;
@@ -1089,8 +1089,7 @@ a:focus{
 }
 // To correspond to the 638px media query above.
 @media screen and (max-width: 638px) {
-  // Because the top menu collapses into a single icon, it takes one click to skip it
-  // entirely. Having buttons positioned relatively/absolutely "off-screen" is
+  // Having .back-to-top and .skip-to-content buttons positioned relatively/absolutely "off-screen" is
   // fine on desktop, but causes problems with overflow mobile-sized screens.
   .back-to-top,
   .skip-to-content {
@@ -1109,6 +1108,30 @@ a:focus{
     margin-top: 5px;
   }
 }
+
+// These are IE10+ and Microsoft Edge specific styles.
+@media screen and (max-width: 638px) and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  header .menu {
+    z-index: 10;
+  }
+
+  header .title.ie {
+    height: auto;
+  }
+
+  .category-nav ul li {
+    margin-right: 10px;
+  }
+
+  .grid-container.home.ie {
+    padding-top: 0;
+
+    & .homepage-intro div {
+      padding-top: 50px;
+    }
+  }
+}
+
 // Phone (portrait)
 @media screen and (max-width: 415px) {
   // HOME PAGE
@@ -1146,10 +1169,6 @@ a:focus{
   }
 }
 
-// To meet WCAG 2.1 success criterion 1.4.10 (Reflow):
-// Content can be presented without loss of information or functionality,
-// and without requiring scrolling in two dimensions for:
-//  - Vertical scrolling content at a width equivalent to 320 CSS pixels
 @media screen and (max-width: 320px) {
   header {
     h1 {
@@ -1169,26 +1188,4 @@ a:focus{
     margin-top: 3.5rem;
   }
 
-}
-
-@media screen and (max-width: 638px) and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-  header .menu {
-    z-index: 10;
-  }
-
-  header .title.ie {
-    height: auto;
-  }
-
-  .category-nav ul li {
-    margin-right: 10px;
-  }
-
-  .grid-container.home.ie {
-    padding-top: 0;
-
-    & .homepage-intro div {
-      padding-top: 50px;
-    }
-  }
 }

--- a/assets/no-script.scss
+++ b/assets/no-script.scss
@@ -55,10 +55,6 @@
 
 /* Verifiable Proof carousel replacement */
 
-.when-no-script {
-  display: none;
-}
-
 .pattern-image noscript {
   width: 100%;
 }


### PR DESCRIPTION
Refactored pattern page so it is easier to read and understand how images are rendered on screen. 
- Removed alt text from image array (refactored pattern markdown pages.)
- Created new liquid variable for alt-text on pattern html page. 
- Refactored 2-image code using built in liquid for-loop properties.
- Refactored 3-image code by letting CSS handle display/hide for images depending on whether user is on mobile, desktop, or viewing without JS. 