### PR TITLE
Remove skip-to-content links

### DIFF
--- a/layouts/partials/page-nav.html
+++ b/layouts/partials/page-nav.html
@@ -1,6 +1,4 @@
 <nav class="grid-container {{ .Type }}">
-  <a class="skip-to-content" href="#content">Skip to content</a>
-  <a class="skip-to-content-noscript" href="#content-noscript">Skip to content</a>
   <div class="page-nav">
     <h1>
       <a href="/" class="title">

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -58,27 +58,6 @@ hr {
 
 /* Accessibility */
 
-.skip-to-content, .skip-to-content-noscript {
-  position: absolute;
-  top: -200px;
-  left: 35px;
-  line-height: 25px;
-}
-
-.skip-to-content:focus, .skip-to-content-noscript:focus {
-  top: 0;
-  background-color: #000F7D;
-  color: white;
-  font-weight: bold;
-  padding: 5px 10px;
-  left: 0;
-  text-decoration: underline;
-}
-
-.skip-to-content-noscript {
-  display: none;
-}
-
 h2#content {
   tabindex: 0;
 }


### PR DESCRIPTION
Generally these are really helpful but without much of a navigation to skip over
they only pass over the header and don't seem super helpful.

The current main page doesn't have a main content element so the links were not
working either.