### PR TITLE
Support markdown in advantages and limitations

### DIFF
--- a/layouts/patterns/single.html
+++ b/layouts/patterns/single.html
@@ -66,7 +66,7 @@
     <ul>
       {{ range .Params.advantages }}
       <li>
-        <span>{{ . }}</span>
+        <span>{{ . | markdownify }}</span>
       </li>
       {{ end }}
     </ul>
@@ -83,7 +83,7 @@
     <ul>
       {{ range .Params.limitations }}
       <li>
-        <span>{{ . }}</span>
+        <span>{{ .  | markdownify }}</span>
       </li>
       {{ end }}
     </ul>

--- a/static/css/pattern-page.css
+++ b/static/css/pattern-page.css
@@ -214,6 +214,14 @@ display: inline-block;
   margin-bottom: 0;
 }
 
+.advantages a, .limitations a {
+  text-decoration: underline;
+}
+
+.advantages a:hover a:focus, .limitations a:hover a:focus {
+  color: #010e7e;
+}
+
 /* Examples */
 
 .examples li {


### PR DESCRIPTION
It'd be good to have links in the advantages/limitations section.

This patch transforms the text in those sections into markdown as well, meaning all formatting should work, as well as markdown-formatted links. There's also styling to appropriately style links.