### PR TITLE
Track 'pattern useful' feedback via Plausible event

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -21,6 +21,7 @@
      }
      </script>
   <script defer data-domain="catalogue.projectsbyif.com" src="https://plausible.io/js/script.js"></script>
+  <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
   <link rel="apple-touch-icon" sizes="152x152" href="{{ "/images/apple-touch-icon.png?v=WGoJrwxmWP" | relURL }}">
   <link rel="icon" type="image/png" sizes="32x32" href="{{ "/images/favicon-32x32.png?v=WGoJrwxmWP" | relURL }}">
   <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png?v=WGoJrwxmWP">

--- a/layouts/partials/pattern-page-feedback.html
+++ b/layouts/partials/pattern-page-feedback.html
@@ -3,18 +3,14 @@
     <div class="grid-x grid-padding-x">
       <div class="large-7 large-offset-3 small-12 cell">
         <div class="feedback">
-          <p class="question">Was this pattern useful?</p>
+          <p class="question">Did you find this pattern useful?</p>
           <div class="feedback-form">
             <form action="/" class="usage-feedback" name="usage" method="post" data-netlify="true">
-              <input type="submit" value="Yes" name="usage" />
+              <input type="submit" value="👍" name="usage" aria-label="Yes, this pattern was useful" />
               <input type="hidden" value="Yes" name="usage" />
             </form>
-            <form action="/" class="usage-feedback" name="usage" method="post" data-netlify="true">
-              <input type="submit" value="No" name="usage" />
-              <input type="hidden" value="No" name="usage" />
-            </form>
           </div>
-          <p class="success-message">Thank you 🙂</p>
+          <p class="success-message">Thanks for letting us know 🙂</p>
         </div>
       </div>
     </div>

--- a/layouts/partials/pattern-page-feedback.html
+++ b/layouts/partials/pattern-page-feedback.html
@@ -1,7 +1,7 @@
 <div class="feedback-and-status">
   <div class="grid-container">
     <div class="grid-x grid-padding-x">
-      <div class="large-7 large-offset-3 small-12 cell">
+      <div class="large-12 small-12 cell">
         <div class="feedback">
           <p class="question">Did you find this pattern useful?</p>
           <div class="feedback-form">

--- a/static/css/pattern-page.css
+++ b/static/css/pattern-page.css
@@ -357,7 +357,7 @@ display: inline-block;
 .feedback {
   display: flex;
   flex-wrap: wrap;
-  justify-content: flex-start;
+  justify-content: center;
   align-items: center;
 }
 
@@ -382,7 +382,7 @@ display: inline-block;
   color: #29283D;
   font-size: 1.3em;
   font-weight: 600;
-  margin: 0 2em 0 0;
+  margin: 0;
 }
 
 .feedback-form .usage-feedback {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -193,10 +193,11 @@ function animateStickyNavOpacity() {
 $(".usage-feedback").submit(function(e) {
   e.preventDefault();
 
-  let $form = $(this);
-  $.post($form.attr("action"), $form.serialize()).then(function() {
-    $('.question').hide();
-    $('.feedback-form').hide();
-    $('.success-message').show();
-  });
+  if (window.plausible) {
+    plausible("pattern-useful");
+  }
+
+  $('.question').hide();
+  $('.feedback-form').hide();
+  $('.success-message').show();
 });


### PR DESCRIPTION
## What

Replaces the dead Netlify form POST on the pattern feedback widget with a Plausible custom event, and tidies up the component.

- **`pattern-useful` Plausible event** — the feedback form now fires `plausible('pattern-useful')` instead of POSTing to Netlify (which was removed in 66985e9, so the form was posting into the void).
- **Per-pattern breakdown without Business tier** — each pattern has its own URL, so filtering the `pattern-useful` goal by **Top Pages** gives per-pattern counts. No custom properties (a Business-tier feature) needed.
- **Dropped the "No" option** — only positive feedback is tracked now.
- **CTA is a 👍** (with an `aria-label` for screen readers) and copy refined: "Did you find this pattern useful?" / "Thanks for letting us know 🙂".
- **Centered** the component within the page width (was offset left by the grid column).

## Plausible setup

Add a single goal in Plausible: custom event `pattern-useful`. Then filter by it and read **Top Pages** for the per-pattern breakdown.

## Verification

Drove the live page via Chrome DevTools Protocol: clicking 👍 calls `plausible('pattern-useful')` exactly once, hides the question, and shows the confirmation message. (No network POST fires on `localhost` — Plausible's `script.js` ignores localhost by design; it will send on the deployed site.)