### PR TITLE
Add Content-Security-Policy and security headers for Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://plausible.io; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://plausible.io; form-action 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; upgrade-insecure-requests"
+        },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=63072000; includeSubDomains; preload"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=()"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What
Adds `vercel.json` applying a Content-Security-Policy plus companion security headers (HSTS, `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`) to all routes.

## The policy
```
default-src 'self';
script-src 'self' 'unsafe-inline' https://plausible.io;
style-src 'self' 'unsafe-inline';
font-src 'self';
img-src 'self' data:;
connect-src 'self' https://plausible.io;
form-action 'self';
base-uri 'self';
object-src 'none';
frame-ancestors 'none';
upgrade-insecure-requests
```

## Source rationale
- `script-src` — self-hosted jQuery/app.js + Plausible.
- `style-src`/`font-src` — self-hosted CSS and the self-hosted IF Sans font (Typekit removed).
- `connect-src` — Plausible event beacons.
- `frame-ancestors 'none'` — clickjacking protection.

## Known caveat
`script-src` requires **`'unsafe-inline'`** because of inline `onclick` handlers (`most-recent.html`, `pattern-card.html`) and inline `<script>` init. We could refactor those handlers into `app.js` in the future.

## Notes
Dep on #105. Assumes the dead Piwik/CMS host is gone, therefore `cms.projectsbyif.com` is intentionally **not** in the allowlist.