### PR TITLE
Restore mint colour for 'Giving and removing consent'

### DIFF
--- a/static/css/homepage.css
+++ b/static/css/homepage.css
@@ -7,7 +7,7 @@
 
 @keyframes colourChange {
   0% {
-    background-color: rgb(156,214,247);
+    background-color: rgb(140,235,200);
   }
 
   20% {
@@ -27,7 +27,7 @@
   }
 
   100% {
-    background-color: rgb(156,214,247);
+    background-color: rgb(140,235,200);
   }
 }
 
@@ -372,7 +372,7 @@ header.page {
 }
 
 .pattern-card.giving-and-removing-consent:hover {
-  box-shadow: 0px 0px 30px 12px rgba(156,214,247, 0.25);
+  box-shadow: 0px 0px 30px 12px rgba(140,235,200, 0.25);
 }
 
 .pattern-card.signing-in-to-a-service:hover {
@@ -396,7 +396,7 @@ header.page {
 }
 
 .pattern-card.giving-and-removing-consent .pattern-card-image{
-  background-color: rgb(156,214,247);
+  background-color: rgb(140,235,200);
 }
 
 .pattern-card.signing-in-to-a-service .pattern-card-image {

--- a/static/css/pattern-page.css
+++ b/static/css/pattern-page.css
@@ -410,15 +410,15 @@ display: inline-block;
 .pattern-image-div.giving-and-removing-consent,
 .related-patterns-image.giving-and-removing-consent,
 .pattern-heading-category.giving-and-removing-consent {
-  background-color: rgb(156,214,247);
+  background-color: rgb(140,235,200);
 }
 
 .related-patterns li.giving-and-removing-consent:hover {
-  box-shadow: 0px 0px 30px 12px rgba(156,214,247, 0.25);
+  box-shadow: 0px 0px 30px 12px rgba(140,235,200, 0.25);
 }
 
 .examples-title a.giving-and-removing-consent:hover {
-  box-shadow: inset 0 -0.2em 0 rgb(156,214,247);
+  box-shadow: inset 0 -0.2em 0 rgb(140,235,200);
 }
 
 .pattern-image-div.signing-in-to-a-service,


### PR DESCRIPTION
## What

Restores the mint `rgb(140,235,200)` / `#8CEBC8` to the **Giving and removing consent** category.

## Why

Lost when the colour palette was aligned to IF brand colours in a previous commit (a146cdc). David asked for it to be restored.

Non-breaking.

## Changes

**`static/css/pattern-page.css`** — pattern page hero, related-pattern thumbnails, category label, and their hover states (lines 413, 417, 421).

**`static/css/homepage.css`** — homepage card thumbnail and card hover glow (lines 399, 375).

**`static/css/homepage.css`** — header `colourChange` animation (lines 10, 30). The `0%` and `100%` stops had collapsed into the same blue as the `20%` stop, so the 30s cycle held a single colour for its first 20%. Restoring mint to `0%`/`100%` puts the category colour back in rotation and removes the dead beat.

The *Signing in to a service* rules keep `rgb(156,214,247)` — that's its own colour, untouched.

## Testing

CSS-only change, no build output affected (`public/` is gitignored). Worth an eyeball on the homepage category view, a consent pattern page, and the header animation.